### PR TITLE
handle plugins as dicts

### DIFF
--- a/djfapi/utils/health_check.py
+++ b/djfapi/utils/health_check.py
@@ -6,8 +6,10 @@ def get_health(response: Response) -> Health:
     from health_check.mixins import CheckMixin
     check = CheckMixin()
 
-    failures = any([not plugin.status for plugin in check.plugins if plugin.critical_service])
-    warnings = any([not plugin.status for plugin in check.plugins if not plugin.critical_service])
+    plugins = check.plugins if type(check.plugins) == list else check.plugins.values()
+
+    failures = any([not plugin.status for plugin in plugins if plugin.critical_service])
+    warnings = any([not plugin.status for plugin in plugins if not plugin.critical_service])
 
     health = Health.parse_obj({
         'status': 'FAILURE' if failures else ('WARNING' if warnings else 'OK'),
@@ -19,7 +21,7 @@ def get_health(response: Response) -> Health:
                     'type': error.message_type,
                     'message': error.message,
                 } for error in plugin.errors],
-            } for plugin in check.plugins
+            } for plugin in plugins
         ]
     })
 


### PR DESCRIPTION
Fixes issue when plugins is an ordereddict instead of a list while retaining backwards compatability

https://github.com/revsys/django-health-check/commit/4da1fd9d7ceffe72d16d01143e1104e119ebac55